### PR TITLE
Add blog posts: Chi War CLI and January 2026 development update

### DIFF
--- a/src/content/blog/2026-01-11-building-chi-war-cli.md
+++ b/src/content/blog/2026-01-11-building-chi-war-cli.md
@@ -1,0 +1,282 @@
+---
+title: "Building the Chi War CLI: A Command-Line Interface for AI-Assisted Tabletop Gaming"
+date: "2026-01-11T12:00:00"
+excerpt: "A deep dive into building a TypeScript command-line interface for Feng Shui 2 campaign management, designed to enable AI-driven tabletop gaming sessions."
+tags: ["chi-war", "typescript", "cli", "ai"]
+---
+
+# Building the Chi War CLI: A Command-Line Interface for AI-Assisted Tabletop Gaming
+
+The Chi War CLI is a TypeScript command-line tool I built to interact with my Feng Shui 2 campaign management application. While the web interface works fine for most tasks, I had a specific goal in mind: creating an interface that Claude Code could use to run tabletop RPG sessions programmatically.
+
+## The Vision: AI as Gamemaster and Player
+
+My objective is to run an experiment where Claude acts as both gamemaster and player. The AI would create a campaign, design an adventure, generate a party of characters, and then run those characters through a combat encounter—making decisions for both sides of the table.
+
+The web app isn't ideal for this workflow. Claude needs a text-based interface where it can issue commands, read structured output, and make decisions based on the results. A CLI fits this requirement exactly.
+
+## Technical Stack
+
+The CLI is built with:
+
+- **TypeScript** with ES modules
+- **Commander.js** for command parsing
+- **Axios** for HTTP requests
+- **Inquirer** for interactive prompts
+- **tsx** for development execution
+
+Configuration is stored in `~/.chiwar/config.json`, tracking the API URL, authentication token, and current campaign/encounter context.
+
+## Authentication: Browser-Based CLI Login
+
+One of the more interesting implementation challenges was authentication. Rather than asking users to paste JWT tokens, I built a browser-based OAuth flow:
+
+```typescript
+export async function loginCommand(): Promise<void> {
+  const { code, url } = await startCliAuth();
+
+  info(`Authorization code: ${code}`);
+  await open(url);  // Opens browser
+
+  // Poll for approval
+  while (attempts < MAX_POLL_ATTEMPTS) {
+    const result = await pollCliAuth(code);
+
+    if (result.status === "approved" && result.token) {
+      setToken(result.token);
+      success(`Logged in as ${result.user.email}`);
+      return;
+    }
+
+    process.stdout.write(`\rWaiting for approval${dots}   `);
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+```
+
+The CLI requests an authorization code from the API, opens the browser to an approval page, then polls every 2 seconds until the user clicks "Approve" in the browser. The JWT token is then stored locally.
+
+## Command Structure
+
+The CLI organizes commands by resource type:
+
+```
+chiwar login                    # Authenticate via browser
+chiwar campaign list            # List campaigns
+chiwar character list           # List characters in current campaign
+chiwar fight create --name "X"  # Create a fight
+chiwar encounter status         # Show combat status
+chiwar ai create "description"  # Generate character with AI
+```
+
+Each command module follows a consistent pattern using Commander.js:
+
+```typescript
+export function registerFightCommands(program: Command): void {
+  const fight = program
+    .command("fight")
+    .description("Manage combat encounters");
+
+  fight
+    .command("list")
+    .option("--active", "Only show active fights")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      try {
+        const result = await listFights(options);
+        // Display logic
+      } catch (err) {
+        error(err instanceof Error ? err.message : "Failed");
+        process.exit(1);
+      }
+    });
+}
+```
+
+## Combat Management
+
+The encounter commands are where the CLI shines for automated gameplay. The `encounter` command provides everything needed to run combat:
+
+```bash
+# Set the active encounter
+chiwar encounter set <fight-id>
+
+# Show current combat status
+chiwar encounter status
+
+# Roll initiative for all combatants
+chiwar encounter initiative
+
+# Execute an attack
+chiwar encounter attack "Johnny" --target "Thug Boss"
+
+# Spend shots (advance in initiative)
+chiwar encounter spend "Johnny" 3
+
+# Drop mooks
+chiwar encounter drop "Thugs" 4
+```
+
+The attack command handles the complete combat resolution:
+
+1. Fuzzy-matches attacker and target names
+2. Rolls or accepts a provided swerve value
+3. Calculates attack total vs. defense
+4. Computes smackdown and wounds
+5. Applies damage to the target
+6. Records the event for the combat log
+
+```typescript
+const result = calculateAttack(attackerMatch, targetMatch, swerve, targetCount);
+
+if (result.hit) {
+  if (result.targetIsMook && result.mooksDropped) {
+    const newCount = Math.max(0, (targetMatch.count || 0) - result.mooksDropped);
+    updates.push({
+      shot_id: targetMatch.shotId,
+      character_id: targetMatch.id,
+      count: newCount,
+      event: { event_type: "attack", description: eventDescription }
+    });
+  }
+}
+
+await applyCombatAction(encounterId, updates);
+```
+
+## Fuzzy Name Matching
+
+Since Claude (or any user) might not type character names exactly, I implemented fuzzy matching:
+
+```typescript
+function findCombatant(query: string, combatants: Combatant[]): Combatant | Combatant[] | null {
+  const q = query.toLowerCase().trim();
+
+  // 1. Exact match
+  const exact = combatants.find((c) => c.name.toLowerCase() === q);
+  if (exact) return exact;
+
+  // 2. Starts-with match
+  const startsWith = combatants.filter((c) => c.name.toLowerCase().startsWith(q));
+  if (startsWith.length === 1) return startsWith[0];
+  if (startsWith.length > 1) return startsWith;  // Return candidates
+
+  // 3. Contains match
+  const contains = combatants.filter((c) => c.name.toLowerCase().includes(q));
+  if (contains.length === 1) return contains[0];
+  if (contains.length > 1) return contains;
+
+  // 4. Word-starts-with match
+  const wordMatch = combatants.filter((c) =>
+    c.name.toLowerCase().split(/\s+/).some((word) => word.startsWith(q))
+  );
+
+  return wordMatch.length === 1 ? wordMatch[0] : wordMatch.length > 1 ? wordMatch : null;
+}
+```
+
+When there are multiple matches, the CLI returns all candidates so the user can be more specific.
+
+## AI Integration
+
+The CLI integrates with the AI features of Chi War:
+
+```bash
+# Generate a character from description
+chiwar ai create "A grizzled Hong Kong detective with martial arts training"
+
+# Generate images for an entity
+chiwar ai image character <character-id>
+
+# Extend a character with AI-generated content
+chiwar ai extend <character-id>
+```
+
+For image generation, the CLI polls the media library until the images appear:
+
+```typescript
+async function pollForNewImages(
+  initialImageIds: Set<string>,
+  expectedCount: number
+): Promise<MediaLibraryImage[] | null> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < POLL_TIMEOUT_MS) {
+    await sleep(POLL_INTERVAL_MS);
+
+    const currentImages = await getOrphanAiImages();
+    const newImages = currentImages.filter((img) => !initialImageIds.has(img.id));
+
+    if (newImages.length >= expectedCount) {
+      return newImages;
+    }
+  }
+  return null;
+}
+```
+
+Once the images are generated, the first one is automatically attached to the entity.
+
+## Notification System
+
+I recently added the ability for gamemasters to send notifications to players:
+
+```bash
+chiwar notification send player@example.com --title "Session Tonight" --message "Game starts at 7pm!"
+```
+
+This integrates with the app's real-time WebSocket notification system, so players see the notification badge update instantly.
+
+## The Upcoming Experiment
+
+With the CLI in place, I can now run my planned experiment. The workflow will look something like:
+
+```bash
+# Claude creates a campaign
+chiwar campaign create --name "The Jade Dragon Conspiracy"
+
+# Claude creates characters
+chiwar ai create "A maverick cop who plays by his own rules"
+chiwar ai create "A reformed triad member seeking redemption"
+
+# Claude creates enemies
+chiwar character create --file villain.json
+chiwar character create --file mooks.json
+
+# Claude sets up the fight
+chiwar fight create --name "Warehouse Showdown"
+chiwar fight add-party <fight-id> <heroes-party-id>
+chiwar fight add-character <fight-id> <villain-id>
+
+# Claude runs the encounter
+chiwar encounter set <fight-id>
+chiwar encounter start
+chiwar encounter initiative
+
+# Combat loop
+chiwar encounter attack "Johnny Fang" --target "Boss Chen"
+chiwar encounter spend "Johnny Fang" 3
+# ... etc
+```
+
+Claude would read the encounter status after each action, decide what the next character should do based on the tactical situation, and issue the appropriate commands.
+
+## Challenges and Lessons
+
+**State Management**: The CLI maintains minimal state—just config and current context IDs. All actual game state lives in the API. This keeps the CLI simple and stateless.
+
+**Error Handling**: Every API call needs graceful error handling with user-friendly messages. I standardized on a pattern of catching errors and using `error()` helper before `process.exit(1)`.
+
+**Output Formatting**: CLI output needs to be readable by both humans and AI. I added `--json` flags to most commands so Claude can parse structured data when needed.
+
+**Polling vs. WebSockets**: For AI operations that take time, polling the API was simpler than setting up WebSocket connections in the CLI. The 3-second poll interval works well enough for background jobs.
+
+## Current Status
+
+The CLI is functional and I use it regularly for testing and development. The code lives in the chi-war repository and can be installed globally with `npm link`.
+
+The AI-as-gamemaster experiment is next. I expect it will reveal edge cases and missing features that I'll need to address. But that's the point—building tools that work for both human and AI users forces a level of API design discipline that benefits everyone.
+
+---
+
+*Chi War is a campaign management application for Feng Shui 2, currently in alpha. The CLI is one component of a larger system that includes a Phoenix/Elixir backend and Next.js frontend.*

--- a/src/content/blog/2026-01-11-chi-war-january-development-update.md
+++ b/src/content/blog/2026-01-11-chi-war-january-development-update.md
@@ -1,0 +1,312 @@
+---
+title: "Chi War Development Update: January 2026"
+date: "2026-01-11T14:00:00"
+excerpt: "A summary of 55+ pull requests merged in January 2026, covering notifications, CLI combat management, Notion integration, and real-time updates."
+tags: ["chi-war", "elixir", "phoenix", "react", "typescript"]
+---
+
+# Chi War Development Update: January 2026
+
+*A summary of 55+ pull requests merged across the Chi War project in the first weeks of January 2026.*
+
+---
+
+## Overview
+
+Chi War is a web application and CLI for managing Feng Shui 2 tabletop RPG campaigns. The system consists of three components: a Phoenix/Elixir backend (shot-elixir), a Next.js frontend (shot-client-next), and a TypeScript command-line interface (chi-war-cli).
+
+This post covers the major features implemented between January 7-11, 2026. The project remains in alpha, with no active player base yet.
+
+---
+
+## Notifications System
+
+I added a complete notifications system for user-facing alerts. The implementation spans both backend and frontend.
+
+### Backend Implementation
+
+The notification schema stores the essential fields:
+
+```elixir
+schema "notifications" do
+  field :type, :string
+  field :title, :string
+  field :message, :string
+  field :payload, :map, default: %{}
+  field :read_at, :utc_datetime
+  field :dismissed_at, :utc_datetime
+
+  belongs_to :user, ShotElixir.Accounts.User
+  timestamps(type: :utc_datetime)
+end
+```
+
+The `payload` field holds structured metadata—campaign context, originating user, and any other relevant data. Two nullable timestamps (`read_at` and `dismissed_at`) track notification state without requiring separate status columns.
+
+The REST API exposes standard CRUD endpoints plus two special operations:
+
+- `GET /api/v2/notifications/unread_count` — Returns a count for badge display
+- `POST /api/v2/notifications/dismiss_all` — Bulk dismissal
+
+A security constraint: the update endpoint only allows modifying `read_at` and `dismissed_at`. Users cannot alter notification content after creation.
+
+### Real-Time Delivery
+
+When a notification is created, Phoenix PubSub broadcasts to the user's channel:
+
+```elixir
+Phoenix.PubSub.broadcast!(
+  ShotElixir.PubSub,
+  "user:#{target_user.id}",
+  {:notification_created, notification}
+)
+```
+
+The frontend subscribes to this channel via WebSocket. Notifications appear instantly without polling.
+
+### Frontend Component
+
+The `NotificationBell` component displays a badge with unread count. Clicking opens a dropdown showing recent notifications with time-ago formatting ("5m ago", "2h ago").
+
+The component subscribes to real-time updates:
+
+```typescript
+useEffect(() => {
+  const unsubscribe = subscribeToNotifications(notification => {
+    setUnreadCount(prev => prev + 1)
+    if (isMenuOpenRef.current) {
+      setNotifications(prev => [notification, ...prev])
+    }
+  })
+  return unsubscribe
+}, [subscribeToNotifications])
+```
+
+A 60-second polling fallback ensures reliability if the WebSocket connection drops.
+
+### Initial Use Case
+
+The first automated notification: AI credit exhaustion. When a user's configured AI provider runs out of credits, the system creates a persistent, dismissable notification instead of showing an ephemeral banner that disappears on page navigation.
+
+---
+
+## CLI Encounter Management
+
+The command-line interface now supports full combat management. Running an entire Feng Shui 2 fight from the terminal is possible.
+
+### Available Commands
+
+```bash
+# Set the active encounter
+chiwar encounter set <fight-id>
+
+# Combat actions
+chiwar encounter attack jack -t "Thunder Cop"
+chiwar encounter wound "Big Boss" 8
+chiwar encounter heal jack 5
+chiwar encounter mooks "Mook Squad" -3
+chiwar encounter spend jack 3
+
+# Dice rolling
+chiwar encounter roll "Martial Arts check"
+chiwar encounter initiative
+
+# Session management
+chiwar encounter start
+chiwar encounter end
+```
+
+### Fuzzy Name Matching
+
+Typing full character names repeatedly is tedious. The CLI implements a four-tier fuzzy matching system:
+
+```typescript
+function findCombatant(query: string, combatants: Combatant[]): Combatant | Combatant[] | null {
+  const q = query.toLowerCase().trim();
+
+  // 1. Exact match
+  const exact = combatants.find(c => c.name.toLowerCase() === q);
+  if (exact) return exact;
+
+  // 2. Starts-with match
+  const startsWith = combatants.filter(c => c.name.toLowerCase().startsWith(q));
+  if (startsWith.length === 1) return startsWith[0];
+  if (startsWith.length > 1) return startsWith;
+
+  // 3. Contains match
+  const contains = combatants.filter(c => c.name.toLowerCase().includes(q));
+  if (contains.length === 1) return contains[0];
+  if (contains.length > 1) return contains;
+
+  // 4. Word-starts-with match
+  const wordMatch = combatants.filter(c =>
+    c.name.toLowerCase().split(/\s+/).some(word => word.startsWith(q))
+  );
+  if (wordMatch.length === 1) return wordMatch[0];
+  if (wordMatch.length > 1) return wordMatch;
+
+  return null;
+}
+```
+
+Typing `jack` matches "Jack Burton". Typing `egg` matches "Egg Shen" via word-starts-with. If multiple characters match, the CLI lists all options and asks for clarification.
+
+### Combat Calculations
+
+Attack resolution follows Feng Shui 2 rules:
+
+```typescript
+export function calculateAttack(
+  attacker: Combatant,
+  target: Combatant,
+  swerve: SwerveResult
+): AttackResult {
+  const effectiveAttack = attackValue - (attacker.impairments || 0);
+  const attackRoll = swerve.total + effectiveAttack;
+  const hit = attackRoll >= defense;
+  const outcome = hit ? attackRoll - defense : 0;
+  const smackdown = hit ? outcome + damage : 0;
+
+  if (targetIsMook) {
+    mooksDropped = Math.min(smackdown, maxMooks);
+  } else {
+    woundsDealt = Math.max(0, smackdown - toughness);
+  }
+}
+```
+
+Dice rolling happens server-side. The API handles exploding dice (6s reroll and add) and returns the swerve result. This keeps the random number generation consistent and auditable.
+
+---
+
+## Notion Integration
+
+Two-way synchronization between Chi War and Notion is now functional.
+
+### Import from Notion
+
+Characters can be created directly from Notion pages:
+
+```bash
+chiwar notion search "Thunder King"
+# Returns matching Notion pages
+
+chiwar character create --from-notion <page-id>
+# Extracts action values, description, and metadata
+```
+
+The system parses Notion properties and maps them to Chi War character fields. Missing fields get sensible defaults rather than null values—a bug fix that prevented frontend crashes.
+
+### Sync Operations
+
+Existing characters linked to Notion pages support bidirectional sync:
+
+- **Push to Notion**: Updates the linked Notion page with current Chi War data
+- **Pull from Notion**: Imports changes made in Notion back to Chi War
+
+Each sync operation is logged with timestamps. A "Prune Old Logs" function removes entries older than 30 days.
+
+### Auto-Unlink Deleted Pages
+
+A subtle but important fix: when a linked Notion page is deleted or archived, Chi War now automatically unlinks it. Previously, the system would repeatedly fail to sync, generating errors indefinitely. Now it detects Notion's "archived" response and clears the `notion_page_id` from the character.
+
+---
+
+## Developer Experience: Workspace Optimization
+
+Creating development workspaces got faster.
+
+### The Problem
+
+Setting up a new git worktree for feature development took 3-4 minutes. Most of that time was Elixir compilation—building the Phoenix application from scratch.
+
+### The Solution
+
+The `create-workspace.sh` script now copies the pre-built `_build` directory:
+
+```bash
+echo ">>> Copying pre-built Elixir artifacts..."
+if [ -d "$MAIN_DIR/shot-elixir/_build" ]; then
+    cp -R "$MAIN_DIR/shot-elixir/_build" shot-elixir/_build
+    echo "    Copied _build from main repo (skips compilation)"
+else
+    echo "    No _build found in main repo, will compile from scratch"
+fi
+```
+
+A 4.2-second copy operation replaces 118 seconds of compilation.
+
+### Results
+
+- **Before**: 190-203 seconds to authenticated development environment
+- **After**: 75-110 seconds
+- **Improvement**: 40-60% faster
+
+Multiple workspaces can run simultaneously on different port offsets. Port 4012/3011 for one feature, 4022/3021 for another. Each workspace is isolated with its own branches in all three repositories.
+
+---
+
+## Role-Based Interface
+
+The frontend now presents different views based on user role.
+
+### Player vs Gamemaster
+
+Players see a simplified dashboard focused on their characters. Gamemasters see the full interface: fights, parties, sites, NPCs, and campaign management tools.
+
+The navigation menu is split into separate GM and Player components. This reduces visual noise for players who don't need campaign administration options.
+
+### Dashboard WebSocket Refresh
+
+Dashboard modules now subscribe to WebSocket channels. When character data changes—through the CLI, another browser tab, or another user—the dashboard updates automatically. No more stale data requiring manual page reloads.
+
+---
+
+## Real-Time Updates Throughout
+
+WebSocket subscriptions were added to several areas:
+
+- **Media Library**: Image uploads, deletions, and attachments trigger live updates
+- **Dashboard**: Character changes reflect immediately
+- **Notifications**: Instant delivery without polling
+
+The pattern is consistent across all real-time features: Phoenix PubSub broadcasts events, frontend components subscribe via channels, and UI updates without user intervention.
+
+---
+
+## Profile Page Reorganization
+
+The profile page was overloaded. It now splits into three focused pages:
+
+- **Profile** (`/profile`): Identity, hero image, campaign memberships
+- **Settings** (`/settings`): Password, passkeys, CLI sessions
+- **Integrations** (`/integrations`): AI providers, Discord linking
+
+Each page serves a distinct purpose. Finding specific settings is easier.
+
+---
+
+## Other Notable Changes
+
+- **CLI browser authentication**: Device authorization flow instead of copy-pasting tokens
+- **CLI session tracking**: See which CLI clients are connected to your account
+- **Branded email templates**: Dark header/footer, amber accents, matching the app aesthetic
+- **Campaign-aware AI images**: Different campaigns can have different AI settings
+- **Provider-agnostic AI credits**: Credit exhaustion warnings work with any configured AI provider
+- **JSON endpoints**: All entity types support `.json` URL suffix for debugging
+- **Number field debounce**: 600ms delay prevents lost keystrokes in rapid input
+
+---
+
+## Summary
+
+The focus areas for this development sprint:
+
+1. **Notifications**: Persistent, dismissable user alerts with real-time delivery
+2. **CLI combat**: Full encounter management from the terminal
+3. **Notion sync**: Bidirectional character synchronization
+4. **Developer tooling**: Faster workspace creation
+5. **Role-based UI**: Tailored interfaces for players and gamemasters
+6. **Real-time updates**: WebSocket subscriptions throughout the application
+
+The project continues to be in alpha. These features prepare the foundation for eventual player testing.


### PR DESCRIPTION
## Summary
- Adds blog post about building the Chi War CLI for AI-assisted tabletop gaming
- Adds January 2026 development update summarizing 55+ merged PRs

## Test plan
- [ ] Verify posts render correctly at `/blog/2026-01-11-building-chi-war-cli`
- [ ] Verify posts render correctly at `/blog/2026-01-11-chi-war-january-development-update`
- [ ] Check frontmatter displays properly (title, date, excerpt, tags)